### PR TITLE
Refactor CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/vivarium_scripts.egg-info

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     package_data={},
     include_package_data=True,
     install_requires=[
-        # 'vivarium-core',
+        'vivarium-core',
+        'pymongo',
     ],
 )


### PR DESCRIPTION
Now the script uses subcommands, which can each have their own arguments. For example, the help outputs now look like this:

```console
$ python scripts/access_db.py -h
usage: access_db.py [-h] [-o HOST] [-p PORT] [-b DATABASE_NAME]
                    {list,delete,info} ...

access experiments from database

positional arguments:
  {list,delete,info}

optional arguments:
  -h, --help            show this help message and exit
  -o HOST, --host HOST  Host at which to access local mongoDB instance.
                        Defaults to "localhost".
  -p PORT, --port PORT  Port at which to access local mongoDB instance.
                        Defaults to "27017".
  -b DATABASE_NAME, --database_name DATABASE_NAME
                        Name of database on local mongoDB instance to read
                        from. Defaults to "simulations".
$ python scripts/access_db.py info -h
usage: access_db.py info [-h] experiment_id [experiment_id ...]

Get info on a list of experiment IDs.

positional arguments:
  experiment_id  Get info on a list of experiment ids. if no arguments
                 provided, displays all experiment info

optional arguments:
  -h, --help     show this help message and exit
```

Now to get info on an experiment, the command is `python scripts/access_db.py info 123` for experiment `123`.

Subcommands will let us build a more complex interface without overwhelming users with options because they can just worry about the options for a particular subcommand.