### PR TITLE
Add Upload and Download Commands

### DIFF
--- a/scripts/access_db.py
+++ b/scripts/access_db.py
@@ -102,7 +102,6 @@ class AccessDB(object):
             downloaded = {
                 'data': data,
                 'environment_config': environment_config,
-                'experiment_id': experiment_id,
             }
             serialized = serialize_value(downloaded)
             with open('{}.json'.format(experiment_id), 'w') as f:
@@ -115,7 +114,6 @@ class AccessDB(object):
                 downloaded = json.load(f)
             data = downloaded['data']
             environment_config = downloaded['environment_config']
-            experiment_id = downloaded['experiment_id']
             data_to_database(data, environment_config, self.db)
 
 


### PR DESCRIPTION
Requires `vivarium-core` commit `c4a22331c294067f20bdff8fd226818d5f521b15`, which is merged in vivarium-collective/vivarium-core#16. This PR should not be merged until the vivarium-core PR is merged.

We download experiments with `python access_db.py download <experiment_id>` and get a JSON file like 
[this](https://github.com/vivarium-collective/vivarium-scripts/files/5302121/20200921.135657.json.zip). We can then upload such a file with `python access_db.py upload <path_to_json>`. Note that experiment IDs are preserved, so the destination database must not already have an experiment with an ID that matches the one being uploaded.

Here are analysis plots of an experiment before and after it was downloaded and re-uploaded:

Before:

![agents](https://user-images.githubusercontent.com/19878639/94622518-5e886a80-0280-11eb-8a39-2b0fab0793d0.png)

After:

![agents](https://user-images.githubusercontent.com/19878639/94622534-647e4b80-0280-11eb-8e68-8bd09ae6a8c4.png)
